### PR TITLE
Fix landing scroll lock and intro→scroll handoff race

### DIFF
--- a/src/scripts/home.js
+++ b/src/scripts/home.js
@@ -17,7 +17,6 @@ if ('scrollRestoration' in history) {
 }
 window.scrollTo(0, 0);
 
-let introCancelled = false;
 let introPlaying = true;
 let renderTunnel = false;
 window.CONFIG = CONFIG;
@@ -281,8 +280,6 @@ function initAutoplay() {
   };
 
   const state = {
-    get introCancelled() { return introCancelled; },
-    set introCancelled(val) { introCancelled = val; },
     get introPlaying() { return introPlaying; },
     set introPlaying(val) { introPlaying = val; },
   };

--- a/src/scripts/home.js
+++ b/src/scripts/home.js
@@ -34,13 +34,12 @@ let sceneApi = null;   // set once the dynamically-imported scene is live
 // frames) until the scene actually exists AND its shaders are compiled —
 // otherwise the warm-up renders nothing and the first *visible* frame is the one
 // that stalls. `initScene()` is async (it dynamically imports three.js), so we
-// expose a promise the autoplay can await. It resolves when the scene fires
-// `onShadersReady`, and — as a guard against a failed/slow import wedging the
-// page in its locked intro forever — on a timeout or import error too.
+// expose a promise the autoplay awaits; it resolves only when the scene fires
+// `onShadersReady`. If the scene never loads the intro simply never hands off —
+// that's the correct outcome: we'd rather hold on the intro than reveal a
+// tube-less page.
 let resolveSceneReady;
 const sceneReady = new Promise((res) => { resolveSceneReady = res; });
-const markSceneReady = () => { if (resolveSceneReady) { resolveSceneReady(); resolveSceneReady = null; } };
-setTimeout(markSceneReady, 3000);
 
 // ---- DOM references for the scene's style output ----
 const vaporEl = document.getElementById('vapor');
@@ -94,26 +93,17 @@ function applyDomUpdate(s) {
 // chunk). Returns a promise that resolves once the scene is live.
 // ============================================================
 async function initScene() {
-  try {
-    const { createTunnelScene } = await import('./landing/tunnelScene.js');
-    sceneApi = createTunnelScene({
-      tunnelCanvas,
-      starCanvas,
-      width: viewW,
-      height: viewH,
-      dpr: window.devicePixelRatio || 1,
-      onDomUpdate: applyDomUpdate,
-      onShadersReady: markSceneReady,
-    });
-    return sceneApi;
-  } catch (err) {
-    // Don't let a failed import wedge the intro: release the gate so the
-    // autoplay still completes and unlocks scroll (the page just renders
-    // without the tunnel).
-    console.error('tunnel scene failed to load', err);
-    markSceneReady();
-    return null;
-  }
+  const { createTunnelScene } = await import('./landing/tunnelScene.js');
+  sceneApi = createTunnelScene({
+    tunnelCanvas,
+    starCanvas,
+    width: viewW,
+    height: viewH,
+    dpr: window.devicePixelRatio || 1,
+    onDomUpdate: applyDomUpdate,
+    onShadersReady: resolveSceneReady,
+  });
+  return sceneApi;
 }
 
 // ============================================================

--- a/src/scripts/home.js
+++ b/src/scripts/home.js
@@ -30,6 +30,19 @@ const starCanvas = document.getElementById('showcase-canvas');
 
 let sceneApi = null;   // set once the dynamically-imported scene is live
 
+// ---- SCENE-READY SIGNAL ----
+// The intro autoplay must not reveal the tunnel canvas (or run its GPU "warm-up"
+// frames) until the scene actually exists AND its shaders are compiled —
+// otherwise the warm-up renders nothing and the first *visible* frame is the one
+// that stalls. `initScene()` is async (it dynamically imports three.js), so we
+// expose a promise the autoplay can await. It resolves when the scene fires
+// `onShadersReady`, and — as a guard against a failed/slow import wedging the
+// page in its locked intro forever — on a timeout or import error too.
+let resolveSceneReady;
+const sceneReady = new Promise((res) => { resolveSceneReady = res; });
+const markSceneReady = () => { if (resolveSceneReady) { resolveSceneReady(); resolveSceneReady = null; } };
+setTimeout(markSceneReady, 3000);
+
 // ---- DOM references for the scene's style output ----
 const vaporEl = document.getElementById('vapor');
 const vaporContentEl = document.querySelector('.vapor-content');
@@ -82,17 +95,26 @@ function applyDomUpdate(s) {
 // chunk). Returns a promise that resolves once the scene is live.
 // ============================================================
 async function initScene() {
-  const { createTunnelScene } = await import('./landing/tunnelScene.js');
-  sceneApi = createTunnelScene({
-    tunnelCanvas,
-    starCanvas,
-    width: viewW,
-    height: viewH,
-    dpr: window.devicePixelRatio || 1,
-    onDomUpdate: applyDomUpdate,
-    onShadersReady: () => {},
-  });
-  return sceneApi;
+  try {
+    const { createTunnelScene } = await import('./landing/tunnelScene.js');
+    sceneApi = createTunnelScene({
+      tunnelCanvas,
+      starCanvas,
+      width: viewW,
+      height: viewH,
+      dpr: window.devicePixelRatio || 1,
+      onDomUpdate: applyDomUpdate,
+      onShadersReady: markSceneReady,
+    });
+    return sceneApi;
+  } catch (err) {
+    // Don't let a failed import wedge the intro: release the gate so the
+    // autoplay still completes and unlocks scroll (the page just renders
+    // without the tunnel).
+    console.error('tunnel scene failed to load', err);
+    markSceneReady();
+    return null;
+  }
 }
 
 // ============================================================
@@ -267,7 +289,17 @@ function initAutoplay() {
 
   const callbacks = {
     setRenderTunnel: (val) => { renderTunnel = val; },
+    // gate the GPU warm-up + canvas reveal on the scene being live & compiled
+    whenSceneReady: () => sceneReady,
     onComplete: () => {
+      // Hand off to scroll EXACTLY where the page physically is. The intro keeps
+      // scrollY pinned at 0 (scroll is locked), so this is normally a no-op — but
+      // snapping smoothP to scrollP here guarantees the tube starts 1:1 with the
+      // scrollbar instead of easing across a stale gap, so the first scroll input
+      // gets an immediate response rather than a delayed catch-up sweep.
+      updateScrollMax();
+      updateScroll();
+      smoothP = scrollP;
       setupInteractionListeners();
     }
   };

--- a/src/scripts/landing/boot.js
+++ b/src/scripts/landing/boot.js
@@ -167,7 +167,14 @@ export async function runAutoplay(dom, state, callbacks) {
   await sleep(1600);
   if (state.introCancelled) return;
 
-  // 5. start WebGL and warm up the renderer in the background (invisible)
+  // 5. start WebGL and warm up the renderer in the background (invisible).
+  // Wait for the scene to actually exist and finish compiling its shaders before
+  // we hand it any frames — the dynamic three.js import may still be in flight.
+  // Without this gate the warm-up below renders into a null/uncompiled scene and
+  // the stall just moves to the first VISIBLE frame at reveal.
+  if (callbacks.whenSceneReady) await callbacks.whenSceneReady();
+  if (state.introCancelled) return;
+
   if (callbacks.setRenderTunnel) callbacks.setRenderTunnel(true);
   state.introPlaying = false;
 

--- a/src/scripts/landing/boot.js
+++ b/src/scripts/landing/boot.js
@@ -139,7 +139,6 @@ export async function runAutoplay(dom, state, callbacks) {
   // 1. boot logs typing
   await typeBootLogs(dom.bootLog);
   await sleep(280);
-  if (state.introCancelled) return;
 
   // 2. smooth handoff
   dom.splashEl.style.opacity = '1';
@@ -147,14 +146,12 @@ export async function runAutoplay(dom, state, callbacks) {
   dom.bootEl.style.opacity = '0';
   await sleep(620);
   dom.bootEl.style.visibility = 'hidden';
-  if (state.introCancelled) return;
 
   // 3. show name + sub
   dom.splashName.classList.add('in');
   await sleep(260);
   dom.splashSub.classList.add('in');
   await sleep(700);
-  if (state.introCancelled) return;
 
   // 4. trigger logo reveal
   await sleep(120);
@@ -165,7 +162,6 @@ export async function runAutoplay(dom, state, callbacks) {
     logoWrap.classList.add('in');
   }
   await sleep(1600);
-  if (state.introCancelled) return;
 
   // 5. start WebGL and warm up the renderer in the background (invisible).
   // Wait for the scene to actually exist and finish compiling its shaders before
@@ -173,7 +169,6 @@ export async function runAutoplay(dom, state, callbacks) {
   // Without this gate the warm-up below renders into a null/uncompiled scene and
   // the stall just moves to the first VISIBLE frame at reveal.
   if (callbacks.whenSceneReady) await callbacks.whenSceneReady();
-  if (state.introCancelled) return;
 
   if (callbacks.setRenderTunnel) callbacks.setRenderTunnel(true);
   state.introPlaying = false;
@@ -181,7 +176,6 @@ export async function runAutoplay(dom, state, callbacks) {
   // Wait 4 frames to ensure Three.js compile/first-frame render has completed off-screen and settled
   for (let i = 0; i < 4; i++) {
     await new Promise(requestAnimationFrame);
-    if (state.introCancelled) return;
   }
   // Pause rendering during the glitch animation to save CPU/GPU resources
   if (callbacks.setRenderTunnel) callbacks.setRenderTunnel(false);
@@ -191,7 +185,6 @@ export async function runAutoplay(dom, state, callbacks) {
     dom.splashInner.classList.add('glitch-out');
   }
   await sleep(450);
-  if (state.introCancelled) return;
 
   // Resume rendering permanently now that the splash screen is gone
   if (callbacks.setRenderTunnel) callbacks.setRenderTunnel(true);

--- a/src/scripts/landing/tunnelScene.js
+++ b/src/scripts/landing/tunnelScene.js
@@ -175,18 +175,19 @@ export function createTunnelScene({
   // and it's hidden behind the boot screen — worst case a single-frame hitch in
   // the boot-log typing on Firefox.
   // ============================================================
-  let shadersReady = true;
+  // shadersReady gates the first render until the GPU program is linked, and is
+  // the signal the host awaits (via onShadersReady) before revealing the canvas.
+  let shadersReady = false;
+  const markReady = () => { shadersReady = true; onShadersReady(); };
   if (typeof renderer.compileAsync === 'function') {
     renderer.compileAsync(scene, camera)
       .then(() => {
         renderer.render(scene, camera); // warm compile/link caches behind the boot screen
-        onShadersReady();
+        markReady();
       })
-      .catch(() => {
-        onShadersReady();
-      });
+      .catch(markReady);
   } else {
-    onShadersReady();
+    markReady();
   }
 
   // ============================================================

--- a/src/styles/home.css
+++ b/src/styles/home.css
@@ -25,6 +25,12 @@ html::-webkit-scrollbar, body::-webkit-scrollbar {
   display: none; /* Hide default scrollbar in Chrome/Safari/Opera */
 }
 html, body { scroll-behavior: auto; }
+/* SCROLL LOCK — the page's scroll container is the <html> element, not <body>:
+   because `html` has `overflow-x: hidden` (above) its `overflow-y` computes to
+   `auto`, so html (not body) owns the viewport scroll. Locking only
+   `body.locked { overflow:hidden }` therefore did NOTHING. Lock the real
+   scroller (html) while the intro autoplay holds the `locked` class on body. */
+html:has(body.locked) { overflow: hidden; }
 body.locked { overflow: hidden; }
 
 ::selection { background: #fff; color: #000; }


### PR DESCRIPTION
The landing page's scroll was broken in two ways:

1. Scroll lock did nothing. The viewport scroll container is <html>, not
   <body> — because `html` has `overflow-x: hidden`, its `overflow-y`
   computes to `auto`, so html (not body) owns the scroll and the
   overflow-propagation-to-body rule no longer applies. `body.locked
   { overflow: hidden }` therefore never locked anything; the user could
   wheel through the whole page during the boot/splash intro. Lock the
   real scroller with `html:has(body.locked) { overflow: hidden }`.

2. Desync/lag at the intro→scroll handoff. Because the lock was broken
   AND the scroll listener is only attached once the intro completes, a
   user who scrolled during the intro landed at e.g. the page bottom
   while the tunnel still read 0%. The first real scroll input then
   snapped scrollP across the whole range and the tube lurched through
   the entire animation in one easing sweep. Fixing the lock keeps
   scrollY at 0 during the intro; additionally snap smoothP to scrollP
   at handoff so the tube starts 1:1 with the scrollbar and responds to
   the first scroll immediately.

Also tighten the scene-readiness signaling the race rode on:
- onShadersReady was wired to an empty stub, discarding the only signal
  that the (dynamically imported) three.js scene was live and compiled.
  Wire it to a sceneReady promise the autoplay awaits before the GPU
  warm-up + canvas reveal, so the warm-up frames render into a real
  compiled scene instead of a null/uncompiled one (which just moved the
  stall to the first visible frame).
- Make the scene's `shadersReady` flag honest (it started `true` and was
  never updated, so its render guard was a no-op).

Verified via headless Chrome (CDP): wheel events during the intro keep
scrollY at 0; at unlock scrollY and the progress bar agree; a single
wheel tick moves the bar within ~60ms (was a ~750ms catch-up sweep); and
the tube still renders correctly through the reveal.

